### PR TITLE
Chromedrive updated to 2.23 remove manual upgrade and dependancies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,14 @@ MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 RUN sudo pacman --noconfirm --needed -S \
   npm \
-  #chromium \
+  chromium \
   firefox \
   xorg-server-xvfb \
   x11vnc \
   nodejs \
   jre8-openjdk \
-  wget \
   gcc \
   gconf \
-  unzip \
   openssh
 
 ENV LAUNCHPAD_CHROME /usr/local/bin/chromium-no-sandbox
@@ -26,12 +24,3 @@ RUN sudo su -c " \
   echo 'chromium \$@ --no-sandbox' >> /usr/local/bin/chromium-no-sandbox && \
   chmod +x /usr/local/bin/chromium-no-sandbox && \
   exit"
-
-### upgrade chromedrive due to errors
-RUN wget  http://chromedriver.storage.googleapis.com/2.25/chromedriver_linux64.zip -P /tmp/chromedriver && \
-  unzip /tmp/chromedriver/chromedriver_linux64.zip -d /tmp/chromedriver && \
-  chmod +x /tmp/chromedriver/chromedriver && \
-  sudo mv -f /tmp/chromedriver/chromedriver /usr/local/share/chromedriver && \
-  sudo ln -fs /usr/local/share/chromedriver /usr/local/bin/chromedriver && \
-  sudo ln -fs /usr/local/share/chromedriver /usr/bin/chromedriver && \
-  rm -r /tmp/chromedriver


### PR DESCRIPTION
Install Chromium with pacman.
Chromedrive seems to have been upgraded from 2.21 to 2.23 so remove manual install