### PR TITLE
Install yarn (to npm global prefix).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV CHROME_BIN /usr/local/bin/chromium-no-sandbox
 ENV CHROMIUM_BIN /usr/local/bin/chromium-no-sandbox
 
 ### downgrade node version due to nodegit error with v0.7.0
-RUN sudo npm install -g n && sudo n 6.9.0
+RUN sudo npm install -g n yarn && sudo n 6.9.0
 
 RUN sudo su -c " \
   echo '#! /bin/sh' > /usr/local/bin/chromium-no-sandbox && \


### PR DESCRIPTION
This allows the Dashboard (and other projects) to migrate to yarn
which is replacing bower/npm. This also makes using yarn in CI much simpler;
no longer have to npm install yarn first and then attempt to run it
locally etc etc.

Furthermore, gulp-yarn does not work if yarn is installed locally.