### PR TITLE
Use upstream version of node by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,6 @@ ENV CHROME_BIN /usr/local/bin/chromium-no-sandbox
 
 ENV CHROMIUM_BIN /usr/local/bin/chromium-no-sandbox
 
-### downgrade node version due to nodegit error with v0.7.0
-RUN sudo npm install -g n && sudo n 6.9.0
-
 RUN sudo su -c " \
   echo '#! /bin/sh' > /usr/local/bin/chromium-no-sandbox && \
   echo 'chromium \$@ --no-sandbox' >> /usr/local/bin/chromium-no-sandbox && \


### PR DESCRIPTION
The runners have access to sudo so can modify the image if needed in their GitLab
CI configuration file.